### PR TITLE
Add macOS support to leechcore_ft601_driver_linux.

### DIFF
--- a/leechcore_ft601_driver_linux/Makefile
+++ b/leechcore_ft601_driver_linux/Makefile
@@ -1,5 +1,16 @@
 CC=gcc
-CFLAGS  += -I. -D LINUX -shared -fPIC -fvisibility=hidden `pkg-config libusb-1.0 --libs --cflags`
+CFLAGS  += -I. -shared -fPIC -fvisibility=hidden `pkg-config libusb-1.0 --libs --cflags`
+
+ifeq ($(shell uname), Linux)
+CFLAGS  += -D LINUX
+LIB = leechcore_ft601_driver_linux.so
+endif
+ifeq ($(shell uname), Darwin)
+LIB = leechcore_ft601_driver_linux.dylib
+CFLAGS  += -D MACOS -install_name @loader_path/$(LIB)
+endif
+
+
 LDFLAGS += -g -shared
 DEPS = leechcore_ft601_driver_linux.h
 OBJ = fpga_libusb.o leechcore_ft601_driver_linux.o
@@ -8,10 +19,10 @@ OBJ = fpga_libusb.o leechcore_ft601_driver_linux.o
 	$(CC) -c -o $@ $< $(CFLAGS)
 
 leechcore_ft601_driver_linux: $(OBJ)
-	$(CC) -o $@ $^ $(CFLAGS) -o leechcore_ft601_driver_linux.so $(LDFLAGS)
+	$(CC) -o $@ $^ $(CFLAGS) -o $(LIB) $(LDFLAGS)
 	rm *.o
 	mkdir -p ../files
-	mv leechcore_ft601_driver_linux.so ../files/
+	mv $(LIB) ../files/
 	true
 
 clean:

--- a/leechcore_ft601_driver_linux/leechcore_ft601_driver_linux.c
+++ b/leechcore_ft601_driver_linux/leechcore_ft601_driver_linux.c
@@ -11,7 +11,10 @@
 __attribute__((visibility("default")))
 uint32_t FT_Create(void *pvArg, uint32_t dwFlags, void **pftHandle)
 {
-    int i, rc;
+    int rc;
+
+#ifndef MACOS
+    int i;
     // first try kernel driver
     {
         // NB! underlying driver will create a device object at /dev/ft60x[0-3]
@@ -26,6 +29,7 @@ uint32_t FT_Create(void *pvArg, uint32_t dwFlags, void **pftHandle)
             }
         }
     }
+#endif /* MACOS */
     // try libusb built-in driver
     {
         rc = fpga_open();


### PR DESCRIPTION
Hi, 

This PR come with the other one on LeechCore to add the macOS support as an host.
Here is a small commit to change the Makefile and leechcore_ft601_driver_linux.c to allow a build on macOS.

Porting the other devices on macOS should be straightforward but I don't have the hardware to test.

Thanks again for this project.