### PR TITLE
Fix buffer overflow in ft601 driver

### DIFF
--- a/leechcore_ft601_driver_linux/fpga_libusb.c
+++ b/leechcore_ft601_driver_linux/fpga_libusb.c
@@ -238,14 +238,14 @@ struct fpga_context* fpga_open(int device_index)
 
     err = libusb_get_string_descriptor_ascii(ctx->device_handle, desc.iProduct, string, sizeof(string));
     if(err) {
-        snprintf(description + strlen(description), sizeof(description), "%s", string);
+        snprintf(description + strlen(description), sizeof(description) - strlen(description), "%s", string);
     } else {
-        snprintf(description + strlen(description), sizeof(description), "%04X", desc.idProduct);
+        snprintf(description + strlen(description), sizeof(description) - strlen(description), "%04X", desc.idProduct);
     }
 
     err = libusb_get_string_descriptor_ascii(ctx->device_handle, desc.iSerialNumber, string, sizeof(string));
     if(err) {
-        snprintf(description + strlen(description), sizeof(description), "%s", string);
+        snprintf(description + strlen(description), sizeof(description) - strlen(description), "%s", string);
     }
 
     vprintfv("[+] %s\n", description);


### PR DESCRIPTION
When trying to run the ft601 plugin, I got a "buffer overflow detected" crash. Specifying the correct length to these snprintf calls seemed to do the trick. I assume there's some difference in my compiler that caught this bug while the one used for development didn't.