### PR TITLE
Use C11 compatible static assert in QEMU-PCILeech Plugin

### DIFF
--- a/leechcore_device_qemu_pcileech/leechcore_device_qemupcileech.c
+++ b/leechcore_device_qemu_pcileech/leechcore_device_qemupcileech.c
@@ -75,7 +75,7 @@ const char *QemuPciLeechErrorReasons[LEECH_KNOWN_ERROR_BITS] =
     "Access denied"
 };
 
-static_assert(LEECH_KNOWN_ERROR_BITS < 32, "The result field has only 32 bits!");
+_Static_assert(LEECH_KNOWN_ERROR_BITS < 32, "The result field has only 32 bits!");
 
 DEVICE_CONTEXT_QEMU_PCILEECH QemuPciLeechContext;
 


### PR DESCRIPTION
`static_assert` is only available in C23, this changes to `_Static_assert` as to be compatible with >= C11 