### PR TITLE
Add Linux character device plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ all:
 	$(MAKE) -C leechcore_device_qemu
 	$(MAKE) -C leechcore_device_qemu_pcileech
 	$(MAKE) -C leechcore_device_skeleton
+	$(MAKE) -C leechcore_device_devmem
 
 clean:
 	$(MAKE) -C leechcore_ft601_driver_linux clean
@@ -15,3 +16,4 @@ clean:
 	$(MAKE) -C leechcore_device_qemu clean
 	$(MAKE) -C leechcore_device_qemu_pcileech clean
 	$(MAKE) -C leechcore_device_skeleton clean
+	$(MAKE) -C leechcore_device_devmem clean

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Plugins are related to various kinds of device drivers allowing for modular exte
 - [leechcore_device_qemu](#leechcore_device_qemu)
 - [leechcore_device_skeleton](#leechcore_device_skeleton)
 - [leechcore_device_qemupcileech](#leechcore_device_qemupcileech)
+- [leechcore_device_devmem](#leechcore_device_devmem)
 
 
 ## leechcore_device_hvsavedstate
@@ -264,3 +265,26 @@ Place leechcore_ft601_driver_macos.dylib and libftd3xx.dylib (from ftdichip) alo
 #### Overview:
 
 The LeechDMA linux kernel driver allows the user to compile a kernel module (.ko) which may be inserted into the kernel. When a LeechDMA device (ZDMA or similar) is connected a device will show up as `/dev/leechdma*` where `*` is a number. User mode programs can then communicate with the LeechDMA linux kernel driver and its connected device.
+
+
+
+## leechcore_device_devmem
+
+#### Authors:
+- Brendan Heinonen ([@staticinvocation](https://github.com/staticinvocation))
+
+#### Supported Platforms:
+- Linux
+
+#### Overview:
+Allows LeechCore to access physical memory through a character device (i.e. `/dev/mem`) on the system.
+
+#### Plugin documentation:
+This plugin has an optional `path` parameter. When specified, the plugin will use the character device specified. By default this value is set to `/dev/mem`.
+
+Example commands:
+- `./pcileech dump -min 0x0 -max 0x10000 -device 'devmem://path=/dev/mem'`
+
+
+#### Installation instructions:
+Place leechcore_device_devmem.so alongside leechcore.so.

--- a/leechcore_device_devmem/Makefile
+++ b/leechcore_device_devmem/Makefile
@@ -1,0 +1,21 @@
+CC=gcc 
+# -Wno-unused-variable -> unused variable in leechcore.h
+CFLAGS  += -I. -I../includes -D LINUX -shared -fPIC -lrt -l:leechcore.so -L. -lm -fvisibility=hidden -g -Wall -Werror  -Wextra -Wno-unused-variable 
+LDFLAGS += -Wl,-rpath,'$$ORIGIN' -g -ldl -shared
+OBJ = leechcore_device_devmem.o
+
+%.o: %.c $(DEPS)
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+leechcore_device_devmem: $(OBJ)
+	cp ../files/leechcore.so . || cp ../../LeechCore*/files/leechcore.so . || true
+	$(CC) -o $@ $^ $(CFLAGS) -o leechcore_device_devmem.so $(LDFLAGS)
+	mkdir -p ../filess
+	mv leechcore_device_devmem.so ../files/
+	rm -f *.o || true
+	rm -f *.so || true
+	true
+
+
+clean:
+	rm -f *.o

--- a/leechcore_device_devmem/leechcore_device_devmem.c
+++ b/leechcore_device_devmem/leechcore_device_devmem.c
@@ -1,0 +1,81 @@
+/*
+* Author: Brendan Heinonen
+*/
+#include "leechcore.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <limits.h>
+
+#include <leechcore_device.h>
+#include <unistd.h>
+
+
+static VOID DeviceDevmem_ReadContigious(PLC_READ_CONTIGIOUS_CONTEXT ctxRC) {
+    int bytes_read;
+    int fd = (intptr_t)ctxRC->ctxLC->hDevice;
+
+    lseek(fd, ctxRC->paBase, SEEK_SET);
+    if ((bytes_read = read(fd, ctxRC->pb, ctxRC->cb)) < 0) {
+        lcprintfvvv(ctxRC->ctxLC, "Failed to read physical memory at 0x%llx (error %d)\n",
+                    ctxRC->paBase, bytes_read);
+    }
+    ctxRC->cbRead = (DWORD)bytes_read;
+}
+
+static BOOL DeviceDevmem_WriteContigious(_In_ PLC_CONTEXT ctxLC,
+                                           _In_ QWORD qwAddr, _In_ DWORD cb,
+                                           _In_reads_(cb) PBYTE pb) {
+    int bytes_written;
+    int fd = (intptr_t)ctxLC->hDevice;
+    lseek(fd, qwAddr, SEEK_SET);
+    if ((bytes_written = write(fd, pb, cb)) < 0) {
+        lcprintfvvv(ctxLC, "Failed to write physical memory at 0x%llx (error %d)\n",
+                    qwAddr, bytes_written);
+        return false;
+    }
+    return true;
+}
+
+VOID DeviceDevmem_Close(_Inout_ PLC_CONTEXT ctxLC)
+{
+    close((intptr_t)ctxLC->hDevice);
+}
+
+_Success_(return) EXPORTED_FUNCTION
+BOOL LcPluginCreate(_Inout_ PLC_CONTEXT ctxLC, _Out_opt_ PPLC_CONFIG_ERRORINFO ppLcCreateErrorInfo)
+{
+    int ret = 0;
+    PLC_DEVICE_PARAMETER_ENTRY pPathParameter = NULL;
+    CHAR szPath[MAX_PATH];
+    int fd;
+
+    lcprintf(ctxLC, "DEVICE: devmem: Initializing\n");
+
+    /* Sanity checks */
+    if(ppLcCreateErrorInfo) { *ppLcCreateErrorInfo = NULL; }
+    if(ctxLC->version != LC_CONTEXT_VERSION) { return false; }
+
+    /* Parse path parameter, or default to /dev/mem */
+    if((pPathParameter = LcDeviceParameterGet(ctxLC, "path"))) {
+        strncpy(szPath, pPathParameter->szValue, sizeof(szPath));
+    } else {
+        strncpy(szPath, "/dev/mem", sizeof(szPath));
+    }
+
+    /* Open the device */
+    fd = open(szPath, O_RDWR | O_SYNC);
+    if(fd < 0) {
+        lcprintf(ctxLC, "DEVICE: devmem: Failed to open device %s (error %d)\n", szPath, errno);
+        return false;
+    }
+
+    /* Assign info and handles for LeechCore */
+    ctxLC->hDevice = (HANDLE)(intptr_t)fd;
+    ctxLC->fMultiThread = false;
+    ctxLC->Config.fVolatile = true;
+    ctxLC->pfnClose = DeviceDevmem_Close;
+    ctxLC->pfnReadContigious = DeviceDevmem_ReadContigious;
+    ctxLC->pfnWriteContigious = DeviceDevmem_WriteContigious;
+    return true;
+}


### PR DESCRIPTION
This plugin allows LeechCore to use a simple Linux character device to access memory. Linux systems (with the appropriate build flags) expose a physical memory character device at `/dev/mem`. This plugin allows the host to self-introspect physical memory via PCILeech.